### PR TITLE
Changing header style include to use double quotes instead of <> as

### DIFF
--- a/include/predicates.hpp
+++ b/include/predicates.hpp
@@ -2,7 +2,7 @@
 #ifndef PREDICATES_HPP
 #define PREDICATES_HPP
 
-#include <predicates.h>
+#include "predicates.h"
 #include <cmath>
 
 namespace predicates {


### PR DESCRIPTION
compilers can not find the include file using <> style.
